### PR TITLE
Fix invalid path in Colab links.

### DIFF
--- a/module3/Module3_Demo3_Build_CBOW.ipynb
+++ b/module3/Module3_Demo3_Build_CBOW.ipynb
@@ -27,7 +27,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/axel-sirota/implement-nlp-word-embedding/blob/main/modul3/Module3_Demo3_Build_CBOW.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/axel-sirota/implement-nlp-word-embedding/blob/main/module3/Module3_Demo3_Build_CBOW.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {

--- a/module3/Module3_Demo4_UsingGlove_For_Sentiment.ipynb
+++ b/module3/Module3_Demo4_UsingGlove_For_Sentiment.ipynb
@@ -26,7 +26,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/axel-sirota/implement-nlp-word-embedding/blob/main/module4/Module3_Demo4_UsingGlove_For_Sentiment.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/axel-sirota/implement-nlp-word-embedding/blob/main/module3/Module3_Demo4_UsingGlove_For_Sentiment.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
Fix two links to the Colab that were not working after the folder rename.
![image](https://user-images.githubusercontent.com/16353002/224376579-2c145d19-f943-45d0-924f-175423f6832d.png)
